### PR TITLE
removing crack dependency

### DIFF
--- a/jiralicious.gemspec
+++ b/jiralicious.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |s|
   s.email       = "jstewart@fusionary.com"
   s.authors     = ["Jason Stewart"]
 
-  s.add_runtime_dependency "crack", "~> 0.1.8"
+  #commenting out dependency crack -- seems unused and has vulnerability
+  #s.add_runtime_dependency "crack", "~> 0.1.8"
   s.add_runtime_dependency "hashie", ">= 1.1"
   s.add_runtime_dependency "httparty", ">= 0.10"
   s.add_runtime_dependency "json", ">= 1.6"

--- a/lib/jiralicious.rb
+++ b/lib/jiralicious.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "hashie"
-require "crack"
+# ~I don't believe this is used~
+#require "crack"
 require "httparty"
 require "json"
 


### PR DESCRIPTION
Just commenting this out for now until we figure out if it is actually used. This version of crack has a known vulnerability.